### PR TITLE
Feature: Action to calculate the size of the repo

### DIFF
--- a/repo-size/action.yaml
+++ b/repo-size/action.yaml
@@ -2,10 +2,10 @@ name: Calculate & update repo size
 description: Calculate and update the repository size in a YAML file
 
 inputs:
-  repo_sizes_file:
+  repo_size_file:
     description: Path to the file where repo sizes will be stored
     required: false
-    default: .github/repo-sizes.yaml
+    default: .github/repo-size.yaml
 
 runs:
   using: composite
@@ -23,21 +23,21 @@ runs:
         }
 
         # Create or replace repo size data file
-        > ${{ inputs.repo_sizes_file }}
+        > ${{ inputs.repo_size_file }}
 
         # Calculate size of the root directory
-        echo "root: $(du -sh . | format_size)" >> ${{ inputs.repo_sizes_file }}
+        echo "root: $(du -sh . | format_size)" >> ${{ inputs.repo_size_file }}
 
         # Calculate size of each first-level subfolder (sorted)
         find . -mindepth 1 -maxdepth 1 -type d | sort | while read -r dir; do
-          echo "  $(basename "$dir"): $(du -sh "$dir" | format_size)" >> ${{ inputs.repo_sizes_file }}
+          echo "  $(basename "$dir"): $(du -sh "$dir" | format_size)" >> ${{ inputs.repo_size_file }}
 
           # Calculate size of each second-level subfolder (sorted)
           find "$dir" -mindepth 1 -maxdepth 1 -type d | sort | while read -r subdir; do
-            echo "    $(basename "$subdir"): $(du -sh "$subdir" | format_size)" >> ${{ inputs.repo_sizes_file }}
+            echo "    $(basename "$subdir"): $(du -sh "$subdir" | format_size)" >> ${{ inputs.repo_size_file }}
           done
         done
 
     - name: Print the repo sizes data file
       shell: bash
-      run: cat ${{ inputs.repo_sizes_file }}
+      run: cat ${{ inputs.repo_size_file }}

--- a/repo-sizes/action.yaml
+++ b/repo-sizes/action.yaml
@@ -1,0 +1,43 @@
+name: Calculate & update repo size
+description: Calculate and update the repository size in a YAML file
+
+inputs:
+  repo_sizes_file:
+    description: Path to the file where repo sizes will be stored
+    required: false
+    default: .github/repo-sizes.yaml
+
+runs:
+  using: composite
+  steps:
+    - name: Calculate and update repo size
+      shell: bash
+      run: |
+        # Define a reusable function to format sizes
+        format_size() {
+          awk '{size=$1; unit=substr(size, length(size), 1); size=substr(size, 1, length(size)-1);
+            if (unit=="G") print size " GB";
+            else if (unit=="M") print size " MB";
+            else if (unit=="K") print size " KB";
+            else print size " B";}'
+        }
+
+        # Create or replace repo size data file
+        > ${{ inputs.repo_sizes_file }}
+
+        # Calculate size of the root directory
+        echo "root: $(du -sh . | format_size)" >> ${{ inputs.repo_sizes_file }}
+
+        # Calculate size of each first-level subfolder (sorted)
+        find . -mindepth 1 -maxdepth 1 -type d | sort | while read -r dir; do
+          echo "  $(basename "$dir"): $(du -sh "$dir" | format_size)" >> ${{ inputs.repo_sizes_file }}
+
+          # Calculate size of each second-level subfolder (sorted)
+          find "$dir" -mindepth 1 -maxdepth 1 -type d | sort | while read -r subdir; do
+            echo "    $(basename "$subdir"): $(du -sh "$subdir" | format_size)" >> ${{ inputs.repo_sizes_file }}
+          done
+        done
+
+    - name: Print the repo sizes data file
+      shell: bash
+      run: cat ${{ inputs.repo_sizes_file }}


### PR DESCRIPTION
# Description - Action to calculate the size of the repo - Issue #5
* Reusable Github Actions that will calculate the size of the root directory
* It will also calculate the sizes of directories within the root directory upto 2 levels
* The calculated sizes are stored in the YAML file 

## How has the change been Tested?
* Manual testing is performed for the new actions added

## Checklist
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings